### PR TITLE
Fix datastore changes + alphabetize dependencies

### DIFF
--- a/complete/app.js
+++ b/complete/app.js
@@ -35,18 +35,20 @@ app.use(session({ signed: true, secret: config.cookieSecret }));
 
 /* Fetch all books and display them */
 app.get('/', function(req, res, next) {
-  books.getAllBooks(function(err, books) {
+  books.getAllBooks(function(err, books, key) {
     if (err) return next(err);
-    res.render('index', { books: books, user: req.session.user });
+    var keyBooks = books.map((book) => Object.assign(book, { id: book.id || book[key].path[1] }));
+    res.render('index', { books: keyBooks, user: req.session.user });
   });
 });
 
 /* Fetch books created by the currently logged in user and display them */
 app.get('/mine', function(req, res, next) {
   if (! req.session.user) return res.redirect('/');
-  books.getUserBooks(req.session.user.id, function(err, books) {
+  books.getUserBooks(req.session.user.id, function(err, books, key) {
     if (err) return next(err);
-    res.render('index', { books: books, user: req.session.user });
+    var keyBooks = books.map((book) => Object.assign(book, { id: book.id || book[key].path[1] }));
+    res.render('index', { books: keyBooks, user: req.session.user });
   });
 });
 

--- a/complete/books.js
+++ b/complete/books.js
@@ -31,12 +31,12 @@ module.exports = function(config) {
 
   function getAllBooks(callback) {
     var query = datastore.createQuery(['Book']);
-    datastore.runQuery(query, callback);
+    datastore.runQuery(query, (err, books) => callback(err, books, datastore.KEY));
   }
 
   function getUserBooks(userId, callback) {
     var query = datastore.createQuery(['Book']).filter('userId', '=', userId);
-    datastore.runQuery(query, callback);
+    datastore.runQuery(query, (err, books) => callback(err, books, datastore.KEY));
   }
 
   function addBook(title, author, coverImageData, userId, callback) {
@@ -44,7 +44,7 @@ module.exports = function(config) {
       key: datastore.key('Book'),
       data: {
         title: title,
-        author: author,
+        author: author
       }
     };
 

--- a/complete/books.js
+++ b/complete/books.js
@@ -67,8 +67,8 @@ module.exports = function(config) {
     datastore.get(key, function(err, book) {
       if (err) return callback(err);
 
-      if (book.data.imageUrl) {
-        var filename = url.parse(book.data.imageUrl).path.replace('/', '')
+      if (book.imageUrl) {
+        var filename = url.parse(book.imageUrl).path.replace('/', '')
         var file = bucket.file(filename);
         file.delete(function(err) {
           if (err) return callback(err);

--- a/complete/package.json
+++ b/complete/package.json
@@ -13,11 +13,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "express": "^4.12.3",
-    "jade": "^1.9.2",
-    "multer": "^0.1.8",
     "cookie-session": "^1.1.0",
+    "express": "^4.12.3",
     "google-cloud": "^0.48.0",
-    "googleapis": "^2.0.3"
+    "googleapis": "^2.0.3",
+    "jade": "^1.9.2",
+    "multer": "^0.1.8"
   }
 }

--- a/complete/views/index.jade
+++ b/complete/views/index.jade
@@ -25,15 +25,15 @@ html(lang="en")
       if books.length
         - each book in books
           .book
-            if book.data.imageUrl
+            if book.imageUrl
               .cover
-                img(src=book.data.imageUrl title="#{book.data.title} by #{book.data.author}")
+                img(src=book.imageUrl title="#{book.title} by #{book.author}")
             else
               .info
-                .title= book.data.title
+                .title= book.title
                 .by - by -
-                .author= book.data.author
-            a.delete(href="/books/delete?id=#{book.key.path[1]}") delete
+                .author= book.author
+            a.delete(href="/books/delete?id=#{book.id}") delete
       else
         .nobooks There are no books!
 

--- a/start/app.js
+++ b/start/app.js
@@ -37,7 +37,8 @@ app.use(session({ signed: true, secret: config.cookieSecret }));
 app.get('/', function(req, res, next) {
   books.getAllBooks(function(err, books) {
     if (err) return next(err);
-    res.render('index', { books: books, user: req.session.user });
+    var keyBooks = books.map((book) => Object.assign(book, { id: book.id || book[key].path[1] }));
+    res.render('index', { books: keyBooks, user: req.session.user });
   });
 });
 
@@ -46,7 +47,8 @@ app.get('/mine', function(req, res, next) {
   if (! req.session.user) return res.redirect('/');
   books.getUserBooks(req.session.user.id, function(err, books) {
     if (err) return next(err);
-    res.render('index', { books: books, user: req.session.user });
+    var keyBooks = books.map((book) => Object.assign(book, { id: book.id || book[key].path[1] }));
+    res.render('index', { books: keyBooks, user: req.session.user });
   });
 });
 

--- a/start/books.js
+++ b/start/books.js
@@ -18,10 +18,7 @@ module.exports = function(config) {
   function getAllBooks(callback) {
     var error = null;
     var books = [
-      {
-        key: { path: ['Book', 12345] },
-        data: { title: 'Fake Book', author: 'Fake Author' }
-      }
+      { id: 12345, title: 'Fake Book', author: 'Fake Author' }
     ];
     callback(error, books);
   }

--- a/start/package.json
+++ b/start/package.json
@@ -14,6 +14,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "express": "^4.12.3",
+    "google-cloud": "^0.48.0",
     "jade": "^1.9.2",
     "multer": "^0.1.8",
     "cookie-session": "^1.1.0"

--- a/start/package.json
+++ b/start/package.json
@@ -13,10 +13,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "cookie-session": "^1.1.0",
     "express": "^4.12.3",
     "google-cloud": "^0.48.0",
     "jade": "^1.9.2",
-    "multer": "^0.1.8",
-    "cookie-session": "^1.1.0"
+    "multer": "^0.1.8"
   }
 }

--- a/start/views/index.jade
+++ b/start/views/index.jade
@@ -25,15 +25,15 @@ html(lang="en")
       if books.length
         - each book in books
           .book
-            if book.data.imageUrl
+            if book.imageUrl
               .cover
-                img(src=book.data.imageUrl title="#{book.data.title} by #{book.data.author}")
+                img(src=book.imageUrl title="#{book.title} by #{book.author}")
             else
               .info
-                .title= book.data.title
+                .title= book.title
                 .by - by -
-                .author= book.data.author
-            a.delete(href="/books/delete?id=#{book.key.path[1]}") delete
+                .author= book.author
+            a.delete(href="/books/delete?id=#{book.id}") delete
       else
         .nobooks There are no books!
 

--- a/step-1-retrieve-books/books.js
+++ b/step-1-retrieve-books/books.js
@@ -24,7 +24,7 @@ module.exports = function(config) {
 
   function getAllBooks(callback) {
     var query = datastore.createQuery(['Book']);
-    datastore.runQuery(query, callback);
+    datastore.runQuery(query, (err, books) => callback(err, books, datastore.KEY));
   }
 
   function getUserBooks(userId, callback) {

--- a/step-1-retrieve-books/package.json
+++ b/step-1-retrieve-books/package.json
@@ -13,10 +13,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "express": "^4.12.3",
-    "jade": "^1.9.2",
-    "multer": "^0.1.8",
     "cookie-session": "^1.1.0",
-    "google-cloud": "^0.48.0"
+    "express": "^4.12.3",
+    "google-cloud": "^0.48.0",
+    "jade": "^1.9.2",
+    "multer": "^0.1.8"
   }
 }

--- a/step-2-create-and-delete-books/books.js
+++ b/step-2-create-and-delete-books/books.js
@@ -24,7 +24,7 @@ module.exports = function(config) {
 
   function getAllBooks(callback) {
     var query = datastore.createQuery(['Book']);
-    datastore.runQuery(query, callback);
+    datastore.runQuery(query, (err, books) => callback(err, books, datastore.KEY));
   }
 
   function getUserBooks(userId, callback) {

--- a/step-3-book-cover-images/books.js
+++ b/step-3-book-cover-images/books.js
@@ -63,8 +63,8 @@ module.exports = function(config) {
     datastore.get(key, function(err, book) {
       if (err) return callback(err);
 
-      if (book.data.imageUrl) {
-        var filename = url.parse(book.data.imageUrl).path.replace('/', '')
+      if (book.imageUrl) {
+        var filename = url.parse(book.imageUrl).path.replace('/', '')
         var file = bucket.file(filename);
         file.delete(function(err) {
           if (err) return callback(err);

--- a/step-3-book-cover-images/books.js
+++ b/step-3-book-cover-images/books.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
 
   function getAllBooks(callback) {
     var query = datastore.createQuery(['Book']);
-    datastore.runQuery(query, callback);
+    datastore.runQuery(query, (err, books) => callback(err, books, datastore.KEY));
   }
 
   function getUserBooks(userId, callback) {

--- a/step-4-user-login/package.json
+++ b/step-4-user-login/package.json
@@ -13,11 +13,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "express": "^4.12.3",
-    "jade": "^1.9.2",
-    "multer": "^0.1.8",
     "cookie-session": "^1.1.0",
+    "express": "^4.12.3",
     "google-cloud": "^0.48.0",
-    "googleapis": "^2.0.3"
+    "googleapis": "^2.0.3",
+    "jade": "^1.9.2",
+    "multer": "^0.1.8"
   }
 }

--- a/step-5-user-books/books.js
+++ b/step-5-user-books/books.js
@@ -31,12 +31,12 @@ module.exports = function(config) {
 
   function getAllBooks(callback) {
     var query = datastore.createQuery(['Book']);
-    datastore.runQuery(query, callback);
+    datastore.runQuery(query, (err, books) => callback(err, books, datastore.KEY));
   }
 
   function getUserBooks(userId, callback) {
     var query = datastore.createQuery(['Book']).filter('userId', '=', userId);
-    datastore.runQuery(query, callback);
+    datastore.runQuery(query, (err, books) => callback(err, books, datastore.KEY));
   }
 
   function addBook(title, author, coverImageData, userId, callback) {

--- a/step-5-user-books/books.js
+++ b/step-5-user-books/books.js
@@ -67,8 +67,8 @@ module.exports = function(config) {
     datastore.get(key, function(err, book) {
       if (err) return callback(err);
 
-      if (book.data.imageUrl) {
-        var filename = url.parse(book.data.imageUrl).path.replace('/', '')
+      if (book.imageUrl) {
+        var filename = url.parse(book.imageUrl).path.replace('/', '')
         var file = bucket.file(filename);
         file.delete(function(err) {
           if (err) return callback(err);

--- a/step-6-deploy/app.js
+++ b/step-6-deploy/app.js
@@ -37,7 +37,8 @@ app.use(session({ signed: true, secret: config.cookieSecret }));
 app.get('/', function(req, res, next) {
   books.getAllBooks(function(err, books) {
     if (err) return next(err);
-    res.render('index', { books: books, user: req.session.user });
+    var keyBooks = books.map((book) => Object.assign(book, { id: book.id || book[key].path[1] }));
+    res.render('index', { books: keyBooks, user: req.session.user });
   });
 });
 
@@ -46,7 +47,8 @@ app.get('/mine', function(req, res, next) {
   if (! req.session.user) return res.redirect('/');
   books.getUserBooks(req.session.user.id, function(err, books) {
     if (err) return next(err);
-    res.render('index', { books: books, user: req.session.user });
+    var keyBooks = books.map((book) => Object.assign(book, { id: book.id || book[key].path[1] }));
+    res.render('index', { books: keyBooks, user: req.session.user });
   });
 });
 


### PR DESCRIPTION
`datastore.runQuery`s result format changed in a recent `google-cloud` update - this PR updates the codelab to match the new `runQuery` version.